### PR TITLE
삼성 디바이스에서 사진 촬영 후 data가 넘어오지 않는 이슈

### DIFF
--- a/app/src/main/java/com/example/allerger/MainActivity.java
+++ b/app/src/main/java/com/example/allerger/MainActivity.java
@@ -315,11 +315,9 @@ public class MainActivity extends AppCompatActivity
                     break;
 
                 case CAMERA_CODE:
-                    if (data != null) {
-                        Intent intent_result_camera = new Intent(MainActivity.this, ResultActivity.class);
-                        intent_result_camera.putExtra("path", currentPhotoPath);
-                        startActivity(intent_result_camera);
-                    }
+                    Intent intent_result_camera = new Intent(MainActivity.this, ResultActivity.class);
+                    intent_result_camera.putExtra("path", currentPhotoPath);
+                    startActivity(intent_result_camera);
                     break;
                 default:
                     break;


### PR DESCRIPTION
우선 수정 자체는 별거 없습니다.
request code가 CAMERA_CODE인 경우에 로직을 보면 data intent를 전혀 사용하고 있지 않네요.
불필요한 null 체크문을 삭제하였습니다.
어차피 이미지 저장을 위한 file path는 저장하고 있기 때문에 바로 ResultActivity로 전달하면 됩니다.

이 문제 자체는 삼성 폰에서만 발생하는 문제?로 보입니다.
https://stackoverflow.com/questions/13430720/getting-uri-null-in-capture-photo-from-camera-intent-in-samsung-mobile